### PR TITLE
Add more language components

### DIFF
--- a/components/data/languageList.ts
+++ b/components/data/languageList.ts
@@ -46,4 +46,6 @@ export const languageList = [
   { name: "Perl", link: "/languages/perl" },
   { name: "Nix", link: "/languages/nix" },
   { name: "Scratch", link: "/languages/scratch" },
+  { name: "YAML", link: "/languages/yaml" },
+  { name: "ZSH", link: "/languages/zsh" },
 ];

--- a/components/languageComponents/YAMLLanguage.tsx
+++ b/components/languageComponents/YAMLLanguage.tsx
@@ -1,0 +1,67 @@
+/* eslint-disable @next/next/no-img-element */
+const YAMLLanguage = () => {
+  return (
+    <div className="flex justify-center items-center bg-primary">
+      <div className="text-center text-slate-50 max-w-2xl">
+        <div className="flex flex-wrap justify-center items-center">
+          <img
+            src="https://img.shields.io/badge/Yaml-60B5CC?style=for-the-badge&logo=yaml&logoColor=white"
+            alt="Yaml"
+            className="mb-10 h-16 rounded-sm"
+          />
+        </div>
+
+        <h2 className="text-2xl font-bold mb-4">What is YAML?</h2>
+        <p className="mb-4">
+          YAML Ain&apos;t Markup Language (YAML) is a data serialization
+          language that is consistently listed as one of the most popular
+          programming languages. It&apos;s often used as a format for
+          configuration files, but its object serialization abilities make it a
+          viable replacement for languages like JSON.
+        </p>
+
+        <h2 className="text-2xl font-bold mb-4">Why Use YAML?</h2>
+        <p className="mb-6">
+          YAML is often used to build configuration files, such as github
+          actions or AWS and Kubernetes to define application configurations, or
+          processes such as CI/CD automations. It relies less on punctuation in
+          comparisson to JSON. This prompts to have much cleaner and concise
+          files.
+        </p>
+
+        <h4 className="text-2xl font-bold my-4">
+          YAML Best Practices and Coding Style Guide
+        </h4>
+        <ul>
+          <li>- Indentation: An indentation of 2 spaces must be used.</li>
+          <li>
+            - Booleans: We should avoid the use of truthy boolean values in
+            YAML. They often throw off people new to YAML. Therefore, we only
+            allow the use of true and false as boolean values, in lower case.
+          </li>
+          <li>Strings are preferably quoted with double quotes (`&quot;`).</li>
+          <li>
+            - Comments: Comments should start with a capital letter and have a
+            space between the comment hash # and the start of the comment.
+          </li>
+          <li>
+            - Mappings: can be written in different styles, however, we only
+            allow the use of block style mappings.
+          </li>
+          <li>
+            - Null values should be implicitly marked. The use of explicit null
+            values should be avoided (~ and null).
+          </li>
+        </ul>
+        <br />
+        <a
+          href="https://yaml.org/"
+          className="text-xl font-bold underline hover:text-blue-400">
+          YAML - Official Documentation
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default YAMLLanguage;

--- a/components/languageComponents/ZSHLanguage.tsx
+++ b/components/languageComponents/ZSHLanguage.tsx
@@ -52,9 +52,9 @@ const ZSHLanguage = () => {
         </ul>
         <br />
         <a
-          href="https://yaml.org/"
+          href="https://zsh.sourceforge.io/Doc/"
           className="text-xl font-bold underline hover:text-blue-400">
-          YAML - Official Documentation
+          ZSH - Official Documentation
         </a>
       </div>
     </div>

--- a/components/languageComponents/ZSHLanguage.tsx
+++ b/components/languageComponents/ZSHLanguage.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable @next/next/no-img-element */
+const ZSHLanguage = () => {
+  return (
+    <div className="flex justify-center items-center bg-primary">
+      <div className="text-center text-slate-50 max-w-2xl">
+        <div className="flex flex-wrap justify-center items-center">
+          <img
+            src="https://img.shields.io/badge/Zsh-60B5CC?style=for-the-badge&logo=Zsh&logoColor=white"
+            alt="Zsh"
+            className="mb-10 h-16 rounded-sm"
+          />
+        </div>
+
+        <h2 className="text-2xl font-bold mb-4">What is ZSH?</h2>
+        <p className="mb-4">
+          The Z shell (Zsh) is a Unix shell that can be used as an interactive
+          login shell and as a command interpreter for shell scripting. Zsh is
+          an extended Bourne shell with many improvements, including some
+          features of Bash, ksh, and tcsh.
+        </p>
+
+        <h2 className="text-2xl font-bold mb-4">Why Use ZSH?</h2>
+        <p className="mb-6">
+          Zsh has powerful scripting capabilities, often considered an
+          improvement over Bash. It supports advanced control structures,
+          improved variable handling, and enhanced arithmetic operations. Zsh
+          can correct typos in your commands, which can be helpful for users who
+          frequently mistype commands or filenames.
+        </p>
+
+        <h4 className="text-2xl font-bold my-4">
+          YAML Best Practices and Coding Style Guide
+        </h4>
+        <ul>
+          <li>
+            Use consistent indentation with spaces (not tabs) for improved
+            readability.
+          </li>
+          <li>
+            - Start Zsh scripts with a shebang line to specify the Zsh
+            interpreter, like `#!/bin/zsh`.
+          </li>
+          <li>Use meaningful and descriptive variable and function names</li>
+          <li>
+            - Define functions clearly and include a comment describing the
+            purpose of the function
+          </li>
+          <li>
+            - Implement error handling in your scripts. You can use set -e to
+            exit on error and set -u to treat unset variables as errors
+          </li>
+        </ul>
+        <br />
+        <a
+          href="https://yaml.org/"
+          className="text-xl font-bold underline hover:text-blue-400">
+          YAML - Official Documentation
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default ZSHLanguage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@types/react": "18.2.17",
         "@types/react-dom": "18.2.7",
         "autoprefixer": "10.4.16",
-        "aws-sdk": "^2.1472.0",
         "axios": "^1.5.1",
         "eslint": "8.50.0",
         "eslint-config-next": "13.5.3",
@@ -1873,26 +1872,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/aws-sdk": {
-      "version": "2.1472.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1472.0.tgz",
-      "integrity": "sha512-U7kAHRbvTy753IXKV8Oom/AqlqnsbXG+Kw5gRbKi6VcsZ3hR/EpNMzdRXTWO5U415bnLWGo8WAqIz67PIaaKsw==",
-      "dependencies": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/axe-core": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
@@ -2102,16 +2081,6 @@
       "integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
       "engines": {
         "node": ">=14.20.1"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -3260,14 +3229,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/execa": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
@@ -3952,21 +3913,6 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -4378,14 +4324,6 @@
       "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
       "bin": {
         "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/jose": {
@@ -6377,15 +6315,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6906,11 +6835,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -7871,44 +7795,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vfile": {
       "version": "6.0.1",
@@ -8064,26 +7954,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/pages/languages/[lang].tsx
+++ b/pages/languages/[lang].tsx
@@ -47,6 +47,8 @@ import ObjectiveCLanguage from "../../components/languageComponents/ObjectiveCLa
 import MATLABLanguage from "../../components/languageComponents/MATLABLanguage";
 import NixLanguage from "../../components/languageComponents/NixLanguage";
 import HTMXLanguage from "../../components/languageComponents/HTMXLanguage";
+import YAMLLanguage from "../../components/languageComponents/YAMLLanguage";
+import ZSHLanguage from "../../components/languageComponents/ZSHLanguage";
 
 const LanguagePage = () => {
   const router = useRouter();
@@ -148,6 +150,10 @@ const LanguagePage = () => {
         return <ObjectiveCLanguage />;
       case "matlab":
         return <MATLABLanguage />;
+      case "yaml":
+        return <YAMLLanguage />;
+      case "zsh":
+        return <ZSHLanguage />;
       default:
         return <LanguageNotSupported />;
     }


### PR DESCRIPTION
This PR fixes #137 by adding two more languages to the existing languages list, in the header navbar to solve this issue: 

While following the guidelines I've made the following changes: 

- Created two new languages, `YAML` and `ZSH`
- Said languages have been added to the `data/languageList.ts`
- Component files, have then also been added to the `pages/languages/[lang].tsx`
- Followed the appropriate linting guidelines. 
- Tested the addition of said languages on the front side, and they appear as intended. 

Let me know if more languages are required. 